### PR TITLE
Introduce a CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,3 +74,15 @@ jobs:
       with:
         name: sanzu_server
         path: ./target/release/sanzu_server
+
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+      - name: Check format
+        run: cargo fmt --all -- --check
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,3 +86,12 @@ jobs:
       - name: Check format
         run: cargo fmt --all -- --check
 
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Security audit
+        uses: actions-rs/audit-check@v1
+        with:
+         token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,3 +95,39 @@ jobs:
         with:
          token: ${{ secrets.GITHUB_TOKEN }}
 
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+      # Dependency list: build/Dockerfile-debian
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y --no-install-recommends \
+          libasound2-dev \
+          ffmpeg \
+          libavutil-dev \
+          libclang-dev \
+          libkrb5-dev \
+          libx264-dev \
+          libx264-dev \
+          libxcb-render0-dev \
+          libxcb-shape0-dev \
+          libxcb-xfixes0-dev \
+          libxdamage-dev \
+          libxext-dev \
+          x264 \
+          xcb \
+          libavformat-dev \
+          libavfilter-dev \
+          libavdevice-dev \
+          dpkg-dev \
+          libpam0g-dev \
+          libdbus-1-dev
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,60 @@ jobs:
         name: sanzu_server
         path: ./target/release/sanzu_server
 
+  build-cross-client-windows:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: sanzu
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: x86_64-pc-windows-gnu
+    # Dependency list: build/Dockerfile-windows
+    - name: Install dependencies
+      run: |
+        sudo apt-get install -y --no-install-recommends \
+        mingw-w64 \
+        pkg-config dpkg-dev python3 \
+        libasound2-dev \
+        ffmpeg \
+        libavutil-dev \
+        libclang-dev \
+        libkrb5-dev \
+        libx264-dev \
+        libx264-dev \
+        libxcb-render0-dev \
+        libxcb-shape0-dev \
+        libxcb-xfixes0-dev \
+        libxdamage-dev \
+        libxext-dev \
+        x264 \
+        xcb \
+        libavformat-dev \
+        libavfilter-dev \
+        libavdevice-dev \
+        dpkg-dev \
+        libpam0g-dev \
+        libdbus-1-dev
+    - name: Build
+      env:
+        RUSTFLAGS: -D warnings
+        PKG_CONFIG_ALLOW_CROSS: 1
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --release --target "x86_64-pc-windows-gnu"
+    - name: Upload resulting 'sanzu_client.exe'
+      uses: actions/upload-artifact@v1
+      with:
+        name: sanzu_client.exe
+        path: ./target/x86_64-pc-windows-gnu/release/sanzu_client.exe
+
+
   fmt:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,76 @@
+name: Build & test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+    # Dependency list: build/Dockerfile-debian
+    - name: Install dependencies
+      run: |
+        sudo apt-get install -y --no-install-recommends \
+        libasound2-dev \
+        ffmpeg \
+        libavutil-dev \
+        libclang-dev \
+        libkrb5-dev \
+        libx264-dev \
+        libx264-dev \
+        libxcb-render0-dev \
+        libxcb-shape0-dev \
+        libxcb-xfixes0-dev \
+        libxdamage-dev \
+        libxext-dev \
+        x264 \
+        xcb \
+        libavformat-dev \
+        libavfilter-dev \
+        libavdevice-dev \
+        dpkg-dev \
+        libpam0g-dev \
+        libdbus-1-dev
+    - name: Build
+      env:
+        RUSTFLAGS: -D warnings
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --release --all --verbose --all-features
+    - name: Run tests
+      run: cargo test --all --release --verbose --all-features
+
+    # Upload resulting artifacts:
+    # sanzu_broker, sanzu_client, sanzu_proxy, sanzu_server
+    - name: Upload resulting 'sanzu_broker'
+      uses: actions/upload-artifact@v1
+      with:
+        name: sanzu_broker
+        path: ./target/release/sanzu_broker
+    - name: Upload resulting 'sanzu_client'
+      uses: actions/upload-artifact@v1
+      with:
+        name: sanzu_client
+        path: ./target/release/sanzu_client
+    - name: Upload resulting 'sanzu_proxy'
+      uses: actions/upload-artifact@v1
+      with:
+        name: sanzu_proxy
+        path: ./target/release/sanzu_proxy
+    - name: Upload resulting 'sanzu_server'
+      uses: actions/upload-artifact@v1
+      with:
+        name: sanzu_server
+        path: ./target/release/sanzu_server


### PR DESCRIPTION
This PR:

* enable `dependabot`, for daily dependency checking and auto-PR of new releases
* add "build & test" job, on linux
* add common checks, such as `cargo-fmt`, `cargo-clippy` and `cargo-audit`
* add a "windows cross-building" job

In addition, the "build & test" job produces `sanzu_broker`, `sanzu_client`, `sanzu_proxy`, `sanzu_server` and export them as artefacts. One can then get a compiled version easily.

For now, some tests are failing:

* ~`cargo clippy`, due to a double `format!` use~
* `cargo audit`, due to an issue with `xcb` (https://rustsec.org/advisories/RUSTSEC-2021-0019.html)
* the cross build for windows, due to an issue with `ffmpeg` already happening in the corresponding `Dockerfile`