### PR TITLE
Add sanzu_server --stdio

### DIFF
--- a/sanzu-common/src/lib.rs
+++ b/sanzu-common/src/lib.rs
@@ -5,7 +5,7 @@ extern crate log;
 pub mod utils;
 #[macro_use]
 pub mod proto;
-pub use proto::{tunnel, ReadWrite, Tunnel};
+pub use proto::{tunnel, ReadWrite, Stdio, Tunnel};
 #[cfg(feature = "kerberos")]
 pub mod auth_kerberos;
 #[cfg(target_family = "unix")]

--- a/sanzu-common/src/proto.rs
+++ b/sanzu-common/src/proto.rs
@@ -22,6 +22,25 @@ const MAX_PACKET_LEN: usize = 100 * 1024 * 1024; // 100 Mo
 pub trait ReadWrite: Read + Write {}
 impl<T: Read + Write> ReadWrite for T {}
 
+pub struct Stdio {}
+
+impl Write for Stdio {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, std::io::Error> {
+        let ret = std::io::stdout().write(buf);
+        self.flush()?;
+        ret
+    }
+    fn flush(&mut self) -> Result<(), std::io::Error> {
+        std::io::stdout().flush()
+    }
+}
+
+impl Read for Stdio {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, std::io::Error> {
+        std::io::stdin().read(buf)
+    }
+}
+
 /// Tunnel object
 pub struct Tunnel {}
 

--- a/sanzu/src/bin/sanzu_server.rs
+++ b/sanzu/src/bin/sanzu_server.rs
@@ -55,6 +55,12 @@ fn main() -> Result<()> {
                 .help("Listen address"),
         )
         .arg(
+            Arg::new("stdio")
+                .long("stdio")
+                .takes_value(false)
+                .help("Uses STDIO instead of listining on a TCP port"),
+        )
+        .arg(
             Arg::new("port")
                 .short('p')
                 .long("port")
@@ -151,6 +157,7 @@ fn main() -> Result<()> {
     let conf = read_server_config(matches.value_of("config").unwrap())
         .context("Cannot read configuration file")?;
     let vsock = matches.is_present("vsock");
+    let stdio = matches.is_present("stdio");
     let unixsock = matches.is_present("unixsock");
     let connect_unixsock = matches.is_present("connect-unixsock");
     let export_video_pci = matches.is_present("export_video_pci");
@@ -160,6 +167,7 @@ fn main() -> Result<()> {
 
     let arguments = ArgumentsSrv {
         vsock,
+        stdio,
         unixsock,
         connect_unixsock,
         address,

--- a/sanzu/src/utils.rs
+++ b/sanzu/src/utils.rs
@@ -14,6 +14,7 @@ pub enum ClipboardSelection {
 
 pub struct ArgumentsSrv<'a> {
     pub vsock: bool,
+    pub stdio: bool,
     pub unixsock: bool,
     pub connect_unixsock: bool,
     pub address: &'a str,


### PR DESCRIPTION
`sanzu_client` comes with a handy `--proxycommand` option. This PR creates a `--stdio` option for `sanzu_server` that makes it use stdin & stdout rather than a TCP connection or a Unix socket.