### PR TITLE
Add clipboard event trig mode

### DIFF
--- a/sanzu/src/utils.rs
+++ b/sanzu/src/utils.rs
@@ -12,6 +12,13 @@ pub enum ClipboardSelection {
     Primary,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum ClipboardConfig {
+    Allow,
+    Deny,
+    Trig,
+}
+
 pub struct ArgumentsSrv<'a> {
     pub vsock: bool,
     pub stdio: bool,
@@ -42,7 +49,7 @@ pub struct ArgumentsClient<'a> {
     pub client_cert: Option<&'a str>,
     pub client_key: Option<&'a str>,
     pub login: bool,
-    pub restrict_clipboard: bool,
+    pub clipboard_config: ClipboardConfig,
     pub window_mode: bool,
     pub decoder_name: Option<&'a str>,
     pub printdir: Option<&'a str>,


### PR DESCRIPTION
Control clipboard behavior:
 - allow: send clipboard to server on local clipboard modification
 - deny: never send local clipboard to server
 - trig: send local clipboard to server on hitting special shortcut

To trigger the send of the clipboard in the "trig" mode, hit the
shortcut  "Ctrl Alt Shift C".