### PR TITLE
Add AMD Radeon encoders

### DIFF
--- a/sanzu/sanzu.toml
+++ b/sanzu/sanzu.toml
@@ -77,3 +77,19 @@ async_depth = "1"
 
 [ffmpeg.h264_v4l2m2m]
 pixel_format = "yuv420p"
+
+[ffmpeg.h264_amf]
+#pixel_format possible values "yuv420p" "nv12"
+pixel_format = "yuv420p"
+#usage possible values  "ultralowlatency" "lowlatency"
+usage = "ultralowlatency"
+#quality possible values "speed" "balanced" "quality"
+quality = "balanced"
+
+[ffmpeg.hevc_amf]
+#pixel_format possible values "yuv420p" "nv12"
+pixel_format = "yuv420p"
+#usage possible values  "ultralowlatency" "lowlatency"
+usage = "ultralowlatency"
+#quality possible values "speed" "balanced" "quality"
+quality = "balanced"

--- a/sanzu/src/video_encoder.rs
+++ b/sanzu/src/video_encoder.rs
@@ -654,8 +654,8 @@ pub fn init_video_encoder<'a>(
 
 pub fn get_encoder_category(encoder_name: &String) -> Result<String> {
     let codec_name = match encoder_name.as_str() {
-        "libx264" | "h264_nvenc" | "h264_qsv" | "h264_v4l2m2m" => "h264",
-        "libx265" | "hevc_nvenc" | "hevc_qsv" => "hevc",
+        "libx264" | "h264_nvenc" | "h264_qsv" | "h264_v4l2m2m" | "h264_amf" => "h264",
+        "libx265" | "hevc_nvenc" | "hevc_qsv" | "hevc_amf" => "hevc",
         "null" => "null",
         _ => {
             return Err(anyhow!("Unknown encoder category: {:?}", encoder_name));


### PR DESCRIPTION
This small pr simply allow sanzu to use ffmpeg encoders for AMD Radeon card h264_amf and hevc_amf.
It also give some initial parameters in sanzu.toml in order to have the encoders working.

The encoders have been tested with sanzu_server on windows 10, and a Navi 22 card, working great !