### PR TITLE
Some random drive-by changes and X11 things

### DIFF
--- a/sanzu/src/client_x11.rs
+++ b/sanzu/src/client_x11.rs
@@ -31,7 +31,7 @@ use x11rb::{
         xproto::*,
         Event,
     },
-    rust_connection::{DefaultStream, RustConnection},
+    rust_connection::RustConnection,
     wrapper::ConnectionExt as _,
     COPY_DEPTH_FROM_PARENT,
 };
@@ -96,7 +96,7 @@ pub struct WindowInfo {
 /// Holds information on the local client
 pub struct ClientInfo {
     /// x11rb connection
-    pub conn: RustConnection<DefaultStream>,
+    pub conn: RustConnection,
     pub root: u32,
     /// Max request size for x11
     pub max_request_size: usize,

--- a/sanzu/src/client_x11.rs
+++ b/sanzu/src/client_x11.rs
@@ -22,7 +22,6 @@ use x11_clipboard::Clipboard;
 use x11rb::{
     connection::{Connection, RequestConnection},
     protocol::{
-        bigreq::{self, ConnectionExt as _},
         randr::{self, ConnectionExt as _},
         shape::{self, ConnectionExt as _},
         shm::{self, ConnectionExt as _},
@@ -56,18 +55,6 @@ fn check_shm_version<C: Connection>(conn: &C) -> Result<(u16, u16)> {
         .reply()
         .context("Error in query shm version reply")?;
     Ok((shm_version.major_version, shm_version.minor_version))
-}
-
-/// Enable Big Request for 4k resolutions and more
-fn enable_big_request<C: Connection>(conn: &C) -> Result<usize> {
-    conn.extension_information(bigreq::X11_EXTENSION_NAME)?;
-
-    let response = conn
-        .bigreq_enable()
-        .context("Error in bigreq test")?
-        .reply()
-        .context("Error in bigreq reply")?;
-    Ok(response.maximum_request_length as usize * 4)
 }
 
 /// Holds information on the local client graphic window
@@ -304,8 +291,7 @@ pub fn init_x11rb(
     }
 
     /* Enable big request for 4k and more */
-    let max_request_size =
-        enable_big_request(&conn).context("Error in activate big request extension")?;
+    let max_request_size = conn.maximum_request_bytes();
     debug!("Max request size: {:?}", max_request_size);
 
     /* Load shape extension */

--- a/sanzu/src/client_x11.rs
+++ b/sanzu/src/client_x11.rs
@@ -1035,12 +1035,8 @@ impl Client for ClientInfo {
             self.clipboard_last_value = Some(data);
         }
 
-        if let Some(last_move) = last_move {
-            events.push(last_move);
-        }
-        if let Some(last_resize) = last_resize {
-            events.push(last_resize);
-        }
+        events.extend(last_move);
+        events.extend(last_resize);
 
         match self.clipboard_config {
             ClipboardConfig::Deny => {}

--- a/sanzu/src/client_x11.rs
+++ b/sanzu/src/client_x11.rs
@@ -399,7 +399,9 @@ pub fn init_x11rb(
 
 /// Set the client image to `img`, with a size of `width`x`height`x4 (32bpp) in 24bpp (rgb)
 fn put_frame(client_info: &mut ClientInfo, img: &[u8], width: u32, height: u32) -> Result<()> {
-    if img.len() < client_info.max_request_size {
+    // The extra size of a PutImage request in addition to the actual payload.
+    let put_image_overhead = 28;
+    if img.len() < client_info.max_request_size - put_image_overhead {
         client_info
             .conn
             .put_image(
@@ -419,7 +421,7 @@ fn put_frame(client_info: &mut ClientInfo, img: &[u8], width: u32, height: u32) 
         // Our image is bigger than the x11 max request size;
         // Split it into chunks with a size below this limit
         let round_size = 0x10000_usize - 1_usize;
-        let max_size = client_info.max_request_size & (!round_size);
+        let max_size = (client_info.max_request_size - put_image_overhead) & (!round_size);
         let max_lines = max_size / (4_usize * width as usize);
         let mut lines_rem = height as usize;
         let mut cur_line = 0_usize;

--- a/sanzu/src/server_x11.rs
+++ b/sanzu/src/server_x11.rs
@@ -59,7 +59,7 @@ use x11rb::{
 /// Holds information on a server side window.
 ///
 /// TODO: for now, we only support rectangle windows.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Area {
     pub drawable: Window,
     pub position: (i16, i16),
@@ -68,8 +68,6 @@ pub struct Area {
     pub is_app: bool,
     pub name: String,
 }
-
-impl Eq for Area {}
 
 impl Ord for Area {
     fn cmp(&self, other: &Self) -> Ordering {
@@ -98,41 +96,9 @@ impl Ord for Area {
     }
 }
 
-impl PartialEq for Area {
-    fn eq(&self, other: &Self) -> bool {
-        self.drawable == other.drawable
-            && self.position == other.position
-            && self.size == other.size
-            && self.mapped == other.mapped
-            && self.is_app == other.is_app
-            && self.name == other.name
-    }
-}
-
 impl PartialOrd for Area {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        let ret = self.drawable.partial_cmp(&other.drawable);
-        if ret != Some(Ordering::Equal) {
-            return ret;
-        }
-
-        let ret = self.size.partial_cmp(&other.size);
-        if ret != Some(Ordering::Equal) {
-            return ret;
-        }
-        let ret = self.position.partial_cmp(&other.position);
-        if ret != Some(Ordering::Equal) {
-            return ret;
-        }
-        let ret = self.mapped.partial_cmp(&other.mapped);
-        if ret != Some(Ordering::Equal) {
-            return ret;
-        }
-        let ret = self.is_app.partial_cmp(&other.is_app);
-        if ret != Some(Ordering::Equal) {
-            return ret;
-        }
-        self.name.partial_cmp(&other.name)
+        Some(self.cmp(other))
     }
 }
 

--- a/sanzu/src/server_x11.rs
+++ b/sanzu/src/server_x11.rs
@@ -721,8 +721,6 @@ pub fn init_x11rb(
     let setup = conn.setup();
     let screen = &setup.roots[screen_num];
 
-    conn.flush().context("Error in x11rb flush")?;
-
     /* Randr */
 
     /* randr extension to detect screen resolution changes */

--- a/sanzu/src/server_x11.rs
+++ b/sanzu/src/server_x11.rs
@@ -1125,11 +1125,6 @@ impl Server for ServerX11 {
                 .context("Error in shm_get_image")?
                 .reply()
                 .context("Error in shm_get_image reply")?;
-
-            if let Err(err) = self.conn.flush() {
-                error!("Connection error {:?}", err);
-                return Err(anyhow!("Connection error"));
-            }
         }
 
         Ok(())

--- a/sanzu/src/server_x11.rs
+++ b/sanzu/src/server_x11.rs
@@ -1237,7 +1237,6 @@ impl Server for ServerX11 {
         self.img_count += 1;
         self.modified_img = false;
         self.modified_area = false;
-        let mut last_clipboard = None;
         let mut events = vec![];
 
         self.conn.flush().context("Cannot flush")?;
@@ -1362,13 +1361,10 @@ impl Server for ServerX11 {
         /* Get clipboard events */
         if let Some(data) = get_clipboard_events(&self.clipboard_event_receiver) {
             let eventclipboard = tunnel::EventClipboard { data };
-            last_clipboard = Some(tunnel::MessageSrv {
+            let clipboard = tunnel::MessageSrv {
                 msg: Some(tunnel::message_srv::Msg::Clipboard(eventclipboard)),
-            });
-        }
-
-        if let Some(last_clipboard) = last_clipboard {
-            events.push(last_clipboard);
+            };
+            events.push(clipboard);
         }
 
         if self.modified_img {

--- a/sanzu/src/server_x11.rs
+++ b/sanzu/src/server_x11.rs
@@ -706,7 +706,7 @@ pub fn init_x11rb(
         {
             break Ok((conn, screen_num));
         }
-        sleep(Duration::new(0, 100_000_000));
+        sleep(Duration::from_millis(100));
     }?;
 
     conn.extension_information(shm::X11_EXTENSION_NAME)

--- a/sanzu/src/server_x11.rs
+++ b/sanzu/src/server_x11.rs
@@ -52,7 +52,7 @@ use x11rb::{
         xtest::ConnectionExt as ConnectionExtXTest,
         Event,
     },
-    rust_connection::{DefaultStream, RustConnection},
+    rust_connection::RustConnection,
     COPY_DEPTH_FROM_PARENT,
 };
 
@@ -344,7 +344,7 @@ pub fn init_area<C: Connection>(conn: &C, root: Window, window: Window) -> Resul
 /// Holds information on the server
 pub struct ServerX11 {
     /// x11 connection handle
-    pub conn: RustConnection<DefaultStream>,
+    pub conn: RustConnection,
     /// x11 graphic information
     pub grabinfo: GrabInfo,
     /// Frame rate limit (see config)


### PR DESCRIPTION
For [`$REASONS`](https://github.com/psychon/x11rb/issues/810) I came across this code base and took a look. This PR contains some random things that resulted from my look. Hopefully, each commit's description says what it does and gives a clear reason.

I would guess that the last commit is the most questionable: https://github.com/cea-sec/sanzu/commit/73bc009efe75ec1a2f37d74c1d82bcc653063ed5
If you want, I can remove this.

I came across the code for creating a cursor in the client (`set_cursor`) that wants to be able to set "nicer" cursors, but touching that seemed a bit too much for now. Hence, I did not implement that. Instead, here is a pointer for some inspiration (ignore the `storage` parameter and just pretend that it is always `None`; this is for re-using some things across a loop): https://github.com/psychon/x11rb/blob/883354bd79536e97941bda38b5d705cc5d974a93/x11rb/src/cursor/mod.rs#L217-L273