### PR TITLE
Cmd line or file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- loop argument renamed to keep-listen
+- clipboard_config argument renamed to clipboard
+- printdir argument renamed to allow-print
+- import_video_shm argument renamed to extern_img_source
+- shm_is_xwd argument renamed to source_is_xwd
+
+### Added
+- Arguments can be taken from file (--config-path) or environment variables
+- Add --proto to the command line
+- Add --version to the command line
+
 ## [0.1.2] - 2023-03-02
 
 ### Added/Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,6 +485,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046ae530c528f252094e4a77886ee1374437744b2bff1497aa898bbddbbb29b3"
 dependencies = [
  "clap_builder",
+ "clap_derive",
+ "once_cell",
 ]
 
 [[package]]
@@ -498,6 +500,18 @@ dependencies = [
  "bitflags 1.3.2",
  "clap_lex",
  "strsim 0.10.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -564,6 +578,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c278839b831783b70278b14df4d45e1beb1aad306c07bb796637de9a0e323e8e"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "config-derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126df0592e12c9f8cc028d8832b9ceaa91f13b1d8b8285953bd1734b768aa83c"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -912,6 +938,15 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "envy"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f47e0157f2cb54f5ae1bd371b30a2ae4311e1c028f575cd4e81de7353215965"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2369,6 +2404,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
+name = "ryu"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2414,8 +2455,10 @@ dependencies = [
  "sanzu-common",
  "serde",
  "serde_derive",
+ "serde_yaml",
  "spin_sleep",
  "toml 0.7.3",
+ "twelf",
  "vsock",
  "webpki-roots",
  "winapi",
@@ -2507,6 +2550,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2524,6 +2578,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2854,6 +2921,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "twelf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b846244c0f498d3d0885b427bd710070f79249613206ff2b07a45d2d1509b845"
+dependencies = [
+ "clap 4.2.1",
+ "config-derive",
+ "envy",
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "toml 0.5.11",
+]
+
+[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2892,6 +2975,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
 
 [[package]]
 name = "untrusted"

--- a/build/Makefile
+++ b/build/Makefile
@@ -36,7 +36,7 @@ almalinux9:
 
 windows:
 	docker build -t sanzu-builder:windows -f Dockerfile-windows .
-	docker run --rm -t $(DOCKER_OPT) -u ${DOCKER_USER} --env CARGO_OPT="-p sanzu --release" sanzu-builder:windows
+	docker run --rm -t $(DOCKER_OPT) -u ${DOCKER_USER} --env CARGO_OPT="-p sanzu --release --features=printfile" sanzu-builder:windows
 	docker run --rm -t $(DOCKER_OPT) -u ${DOCKER_USER} sanzu-builder:windows bash -c \
 		"cd /usr/x86_64-w64-mingw32/lib/ \
 		; cp ../bin/libopus-0.dll swscale-*.dll postproc-*.dll \

--- a/sanzu/Cargo.toml
+++ b/sanzu/Cargo.toml
@@ -35,7 +35,9 @@ rustls-pemfile = "1.0"
 sanzu-common = { path="../sanzu-common", default-features = false}
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
+serde_yaml = "0.9"
 spin_sleep = "1.1"
+twelf = {version = "0.10.0", features=["toml"]}
 toml = "0.7"
 dbus = { version = "0.9", optional = true }
 dbus-crossroads = { version = "0.5", optional = true }

--- a/sanzu/src/bin/sanzu_client.rs
+++ b/sanzu/src/bin/sanzu_client.rs
@@ -1,37 +1,30 @@
 #![windows_subsystem = "windows"]
+use anyhow::Result;
+
 #[macro_use]
 extern crate log;
 
-use clap::{builder::PossibleValue, Arg, ArgAction, Command};
+use clap::CommandFactory;
 
 use sanzu::{
     client,
     config::{read_client_config, ConfigClient},
-    utils::{ArgumentsClient, ClipboardConfig},
+    utils::{ClientArgs, ClientArgsConfig},
 };
 
 use sanzu_common::proto::VERSION;
 
 use std::collections::HashMap;
 
+use twelf::Layer;
+
 #[cfg(windows)]
 use winapi::um::wincon;
 
-fn main() {
+fn main() -> Result<()> {
     env_logger::Builder::from_default_env()
         .format_timestamp_nanos()
         .init();
-
-    let about = format!(
-        r#"Sanzu client: desktop video streaming
-
-Protocol version: {VERSION:?}
-
-To change log level:
-RUST_LOG=debug
-RUST_LOG=info
-"#
-    );
 
     #[cfg(windows)]
     {
@@ -40,285 +33,41 @@ RUST_LOG=info
         }
     }
 
-    let command = Command::new("Sanzu client")
-        .version(env!("CARGO_PKG_VERSION"))
-        .about(about)
-        .arg(
-            Arg::new("server_addr")
-                .help("Sets the server IP (Ex: 127.0.0.1)")
-                .required(true)
-                .index(1),
-        )
-        .arg(
-            Arg::new("server_port")
-                .help("Sets the server port (Ex: 1122)")
-                .required(true)
-                .value_parser(clap::value_parser!(u16))
-                .index(2),
-        )
-        .arg(
-            Arg::new("config")
-                .short('f')
-                .long("config")
-                .help("configuration file")
-                .num_args(1),
-        )
-        .arg(
-            Arg::new("audio")
-                .help("Forward audio")
-                .short('a')
-                .long("audio")
-                .action(ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("tls_ca")
-                .help("Enable tls encryption / server authentication")
-                .short('t')
-                .long("tls_ca")
-                .num_args(1),
-        )
-        .arg(
-            Arg::new("tls_server_name")
-                .help("Server name for tls tunnel")
-                .short('n')
-                .long("tls_server_name")
-                .num_args(1),
-        )
-        .arg(
-            Arg::new("client_cert")
-                .help("Use client cert authentication")
-                .short('c')
-                .long("client_cert")
-                .num_args(1),
-        )
-        .arg(
-            Arg::new("client_key")
-                .help("Client cert key")
-                .short('x')
-                .long("client_key")
-                .num_args(1),
-        )
-        .arg(
-            Arg::new("audio_buffer_ms")
-                .help("Audio buffer ms (default: 150ms)")
-                .short('b')
-                .long("audio_buffer_ms")
-                .value_parser(clap::value_parser!(u32))
-                .num_args(1),
-        )
-        .arg(
-            Arg::new("audio_sample_rate")
-                .help("Audio sample rate")
-                .short('s')
-                .long("audio_sample_rate")
-                .value_parser(clap::value_parser!(u32))
-                .num_args(1),
-        )
-        .arg(
-            Arg::new("login")
-                .help("Use login/password to authenticate")
-                .short('l')
-                .long("login")
-                .action(ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("clipboard")
-                .help(r#"Control clipboard behavior:
- - allow: send clipboard to server on local clipboard modification
- - deny: never send local clipboard to server
- - trig: send local clipboard to server on hitting special shortcut
-"#)
-                .short('q')
-                .long("clipboard")
-                .num_args(1)
-                .default_missing_value("allow")
-                .value_parser([
-                    PossibleValue::new("allow"),
-                    PossibleValue::new("deny"),
-                    PossibleValue::new("trig"),
-                ]),
-        )
-        .arg(
-            Arg::new("window-mode")
-                .help("Client will be in window mode instead of fullscreen")
-                .short('w')
-                .long("window-mode")
-                .action(ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("decoder")
-                .short('d')
-                .long("decoder")
-                .num_args(1)
-                .help("Force decoder name (libx264, h264_qsv, ...) (must be compatible with selected encoder)"),
-        )
-        .arg(
-            Arg::new("allow-print")
-                .short('j')
-                .long("allow-print")
-                .num_args(1)
-                .help(
-                    r#""Allow print order from serveur to local printing service.
-The argument is the local firectory base which contains files to print
-Ex: -j c:\user\dupond\printdir\
-"#)
-        )
-        .arg(
-            Arg::new("sync_key_locks")
-                .help("Synchronize caps/num/scroll lock")
-                .short('g')
-                .long("sync_key_locks")
-                .action(ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("import_video_shm")
-                .short('i')
-                .long("import_video_shm")
-                .num_args(1)
-                .help(
-                    "Input video from shared memory\n\
-                     Example: if the video server runs in a vm,\n\
-                     the video buffer is exfiltrated using guest/host shared memory instead of\n\
-                     tcp or vsock",
-                ),
-        )
-        .arg(
-            Arg::new("shm_is_xwd")
-                .help("Input from shared memory is in xwd format")
-                .short('y')
-                .long("shm_is_xwd")
-                .num_args(0),
-        )
-        .arg(
-            Arg::new("proxycommand")
-                .short('p')
-                .long("proxycommand")
-                .num_args(1)
-                .help("Command to execute to establish connection"),
-        )
-        .arg(
-            Arg::new("title")
-                .long("title")
-                .num_args(1)
-                .help("Window's title (default: 'Sanzu client')"),
-        )
-        .arg(
-            Arg::new("grab_keyboard")
-                .help(
-                    "Grab and keep keyboard on focus.\n\
-                     This allows (linux) sending special keys like alt-tab\
-                     without being interpreted by the local window manager"
-                )
-                .short('u')
-                .long("grab_keyboard")
-                .action(ArgAction::SetTrue),
-        );
-    #[cfg(unix)]
-    let command = command.arg(
-        Arg::new("vsock")
-            .short('v')
-            .long("vsock")
-            .num_args(0)
-            .help("Use vsock"),
-    );
+    let matches = ClientArgs::command().get_matches();
+    let config_path = matches.get_one::<std::path::PathBuf>("config_path");
 
-    #[cfg(feature = "kerberos")]
-    let command = command.arg(
-        Arg::new("server_cname")
-            .help("Enable kerberos using server cname")
-            .short('k')
-            .long("server_cname")
-            .num_args(1),
-    );
-    let matches = command.get_matches();
-
-    let server_addr = matches
-        .get_one::<String>("server_addr")
-        .expect("Server address is mandatory");
-
-    let server_port = *matches.get_one::<u16>("server_port").unwrap_or(&1122);
-
-    #[cfg(unix)]
-    let vsock = matches.get_flag("vsock");
-    let audio_buffer_ms = *matches.get_one::<u32>("audio_buffer_ms").unwrap_or(&150);
-
-    let audio_sample_rate = matches.get_one::<u32>("audio_sample_rate").cloned();
-
-    let audio = matches.get_flag("audio");
-    let server_cname = matches.get_one::<String>("server_cname").cloned();
-    let tls_ca = matches.get_one::<String>("tls_ca").cloned();
-    let client_cert = matches.get_one::<String>("client_cert").cloned();
-    let client_key = matches.get_one::<String>("client_key").cloned();
-    let tls_server_name = matches.get_one::<String>("tls_server_name").cloned();
-    let login = matches.get_flag("login");
-    let grab_keyboard = matches.get_flag("grab_keyboard");
-
-    let clipboard_config = match matches
-        .get_one::<String>("clipboard")
-        .unwrap_or(&"allow".to_string())
-        .as_str()
-    {
-        "allow" => ClipboardConfig::Allow,
-        "deny" => ClipboardConfig::Deny,
-        "trig" => ClipboardConfig::Trig,
-        _ => {
-            panic!("Unknown clipboard configuration");
-        }
+    let mut layers = if let Some(config_path) = config_path {
+        vec![Layer::Toml(config_path.into())]
+    } else {
+        vec![]
     };
+    layers.append(&mut vec![
+        Layer::Env(Some(String::from("SANZU_"))),
+        Layer::Clap(matches),
+    ]);
 
-    let window_mode = matches.get_flag("window-mode");
-    let decoder_name = matches.get_one::<String>("decoder").cloned();
-    let printdir = matches.get_one::<String>("allow-print").cloned();
-    let client_config = match matches.get_one::<String>("config") {
-        Some(config_path) => {
-            read_client_config(config_path).expect("Cannot read configuration file")
+    let client_config = ClientArgsConfig::with_layers(&layers).unwrap();
+
+    if client_config.proto {
+        println!("Protocol version: {VERSION}");
+        return Ok(());
+    }
+
+    let conf = match client_config.config {
+        Some(ref client_config) => {
+            read_client_config(client_config).expect("Cannot read configuration file")
         }
         None => ConfigClient {
             ffmpeg: HashMap::new(),
         },
     };
-    let proxycommand = matches.get_one::<String>("proxycommand").cloned();
-    let sync_key_locks = matches.get_flag("sync_key_locks");
-    let import_video_shm = matches.get_one::<String>("import_video_shm").cloned();
-    let shm_is_xwd = matches.get_flag("shm_is_xwd");
-    let default_title = "Sanzu client".to_string();
-    let title = matches
-        .get_one::<String>("title")
-        .unwrap_or(&default_title)
-        .as_str();
-
-    let arguments = ArgumentsClient {
-        server_addr,
-        server_port,
-        #[cfg(unix)]
-        vsock,
-        audio,
-        audio_sample_rate,
-        audio_buffer_ms,
-        server_cname,
-        tls_ca,
-        tls_server_name,
-        client_cert,
-        client_key,
-        login,
-        clipboard_config,
-        window_mode,
-        decoder_name,
-        printdir,
-        proxycommand,
-        sync_key_locks,
-        video_shared_mem: import_video_shm,
-        shm_is_xwd,
-        title,
-        grab_keyboard,
-    };
-
     if let Err(err) = client::run(
+        &conf,
         &client_config,
-        &arguments,
         client::StdioClientInterface::default(),
     ) {
         error!("Client error");
         err.chain().for_each(|cause| error!(" - due to {}", cause));
     }
+    Ok(())
 }

--- a/sanzu/src/bin/sanzu_client.rs
+++ b/sanzu/src/bin/sanzu_client.rs
@@ -9,7 +9,7 @@ use clap::CommandFactory;
 use sanzu::{
     client,
     config::{read_client_config, ConfigClient},
-    utils::{ClientArgs, ClientArgsConfig},
+    utils::{init_logger, ClientArgs, ClientArgsConfig},
 };
 
 use sanzu_common::proto::VERSION;
@@ -22,10 +22,6 @@ use twelf::Layer;
 use winapi::um::wincon;
 
 fn main() -> Result<()> {
-    env_logger::Builder::from_default_env()
-        .format_timestamp_nanos()
-        .init();
-
     #[cfg(windows)]
     {
         unsafe {
@@ -52,6 +48,8 @@ fn main() -> Result<()> {
         println!("Protocol version: {VERSION}");
         return Ok(());
     }
+
+    init_logger(client_config.verbose);
 
     let conf = match client_config.config {
         Some(ref client_config) => {

--- a/sanzu/src/bin/sanzu_client.rs
+++ b/sanzu/src/bin/sanzu_client.rs
@@ -1,15 +1,14 @@
 #![windows_subsystem = "windows"]
 use anyhow::Result;
+use clap::CommandFactory;
 
 #[macro_use]
 extern crate log;
 
-use clap::CommandFactory;
-
 use sanzu::{
     client,
     config::{read_client_config, ConfigClient},
-    utils::{init_logger, ClientArgs, ClientArgsConfig},
+    utils::{init_logger, is_proto_arg, ClientArgs, ClientArgsConfig},
 };
 
 use sanzu_common::proto::VERSION;
@@ -29,6 +28,11 @@ fn main() -> Result<()> {
         }
     }
 
+    if is_proto_arg() {
+        println!("Protocol version: {VERSION}");
+        return Ok(());
+    }
+
     let matches = ClientArgs::command().get_matches();
     let config_path = matches.get_one::<std::path::PathBuf>("config_path");
 
@@ -44,12 +48,12 @@ fn main() -> Result<()> {
 
     let client_config = ClientArgsConfig::with_layers(&layers).unwrap();
 
+    init_logger(client_config.verbose);
+
     if client_config.proto {
         println!("Protocol version: {VERSION}");
         return Ok(());
     }
-
-    init_logger(client_config.verbose);
 
     let conf = match client_config.config {
         Some(ref client_config) => {

--- a/sanzu/src/bin/sanzu_proxy.rs
+++ b/sanzu/src/bin/sanzu_proxy.rs
@@ -1,158 +1,45 @@
+use anyhow::{Context, Result};
+use clap::CommandFactory;
+
 #[macro_use]
 extern crate log;
 
-use clap::{Arg, ArgAction, Command};
-use sanzu::{config::read_server_config, proxy, utils::ArgumentsProxy};
+use sanzu::{
+    config::read_server_config,
+    proxy,
+    utils::{ProxyArgs, ProxyArgsConfig},
+};
 use sanzu_common::proto::VERSION;
-use std::net::IpAddr;
 
-const DEFAULT_CONFIG: &str = "/etc/sanzu.toml";
+use twelf::Layer;
 
-fn main() {
+fn main() -> Result<()> {
     env_logger::Builder::from_default_env().init();
 
-    let about = format!(
-        r#"Sanzu proxy: desktop video streaming
+    let matches = ProxyArgs::command().get_matches();
+    let config_path = matches.get_one::<std::path::PathBuf>("config_path");
 
-Protocol version: {VERSION:?}
-"#
-    );
-
-    let matches = Command::new("Sanzu proxy")
-        .version(env!("CARGO_PKG_VERSION"))
-        .about(about)
-        .arg(
-            Arg::new("server_ip")
-                .help("Sets the server IP (Ex: 127.0.0.1)")
-                .required(true)
-                .index(1),
-        )
-        .arg(
-            Arg::new("server_port")
-                .help("Sets the server port (Ex: 122)")
-                .required(true)
-                .index(2),
-        )
-        .arg(
-            Arg::new("config")
-                .short('f')
-                .long("config")
-                .help("configuration file")
-                .default_value(DEFAULT_CONFIG)
-                .num_args(1),
-        )
-        .arg(
-            Arg::new("vsock")
-                .short('v')
-                .long("vsock")
-                .num_args(0)
-                .help("Use vsock"),
-        )
-        .arg(
-            Arg::new("listen")
-                .short('l')
-                .long("listen")
-                .num_args(1)
-                .default_value("127.0.0.1")
-                .value_parser(clap::value_parser!(IpAddr))
-                .help("Listen address"),
-        )
-        .arg(
-            Arg::new("listen_port")
-                .short('p')
-                .long("port")
-                .num_args(1)
-                .value_parser(clap::value_parser!(u16))
-                .help("Bind port number"),
-        )
-        .arg(
-            Arg::new("connect_unix_socket")
-                .short('u')
-                .long("unix_socket")
-                .num_args(1)
-                .help("Path of the unix socket to connect to instead of listening for the client"),
-        )
-        .arg(
-            Arg::new("encoder")
-                .short('e')
-                .long("encoder")
-                .num_args(1)
-                .help("Encoder name (libx264, h264_nvenc, ...)"),
-        )
-        .arg(
-            Arg::new("audio")
-                .help("Allow audio forwarding")
-                .short('a')
-                .long("audio")
-                .num_args(0),
-        )
-        .arg(
-            Arg::new("import_video_shm")
-                .short('i')
-                .long("import_video_shm")
-                .num_args(1)
-                .help(
-                    "Input video from shared memory\n\
-                     Example: if the video server runs in a vm,\n\
-                     the video buffer is exfiltrated using guest/host shared memory instead of\n\
-                     tcp or vsock",
-                ),
-        )
-        .arg(
-            Arg::new("shm_is_xwd")
-                .help("Input from shared memory is in xwd format")
-                .short('x')
-                .long("shm_is_xwd")
-                .num_args(0),
-        )
-        .arg(
-            Arg::new("loop")
-                .help("Endless server clients")
-                .short('d')
-                .long("loop")
-                .action(ArgAction::SetTrue),
-        )
-        .get_matches();
-
-    let server_addr = matches
-        .get_one::<String>("server_ip")
-        .expect("Cannot parse server ip address");
-
-    let listen_address = *matches.get_one::<IpAddr>("listen").unwrap();
-
-    let server_port = matches.get_one::<String>("server_port").unwrap();
-
-    let listen_port = matches.get_one::<u16>("listen_port").cloned();
-
-    let unix_socket = matches.get_one::<String>("connect_unix_socket").cloned();
-
-    let audio = matches.get_flag("audio");
-    let encoder_name = matches
-        .get_one::<String>("encoder")
-        .unwrap_or(&"libx264".to_string())
-        .to_owned();
-    let conf = read_server_config(matches.get_one::<String>("config").unwrap()).unwrap();
-    let vsock = matches.get_flag("vsock");
-    let import_video_shm = matches.get_one::<String>("import_video_shm").cloned();
-    let shm_is_xwd = matches.get_flag("shm_is_xwd");
-    let endless_loop = matches.get_flag("loop");
-
-    let arguments = ArgumentsProxy {
-        vsock,
-        server_addr,
-        server_port,
-        listen_address,
-        listen_port,
-        unix_socket,
-        encoder_name,
-        audio,
-        video_shared_mem: import_video_shm,
-        shm_is_xwd,
-        endless_loop,
+    let mut layers = if let Some(config_path) = config_path {
+        vec![Layer::Toml(config_path.into())]
+    } else {
+        vec![]
     };
+    layers.append(&mut vec![
+        Layer::Env(Some(String::from("SANZU_"))),
+        Layer::Clap(matches),
+    ]);
 
-    if let Err(err) = proxy::run(&conf, &arguments) {
+    let proxy_config = ProxyArgsConfig::with_layers(&layers).unwrap();
+
+    if proxy_config.proto {
+        println!("Protocol version: {VERSION}");
+        return Ok(());
+    }
+    let conf =
+        read_server_config(&proxy_config.config).context("Cannot read configuration file")?;
+    if let Err(err) = proxy::run(&conf, &proxy_config) {
         error!("Proxy error");
         err.chain().for_each(|cause| error!(" - due to {}", cause));
     }
+    Ok(())
 }

--- a/sanzu/src/bin/sanzu_proxy.rs
+++ b/sanzu/src/bin/sanzu_proxy.rs
@@ -7,13 +7,19 @@ extern crate log;
 use sanzu::{
     config::read_server_config,
     proxy,
-    utils::{init_logger, ProxyArgs, ProxyArgsConfig},
+    utils::{init_logger, is_proto_arg, ProxyArgs, ProxyArgsConfig},
 };
+
 use sanzu_common::proto::VERSION;
 
 use twelf::Layer;
 
 fn main() -> Result<()> {
+    if is_proto_arg() {
+        println!("Protocol version: {VERSION}");
+        return Ok(());
+    }
+
     let matches = ProxyArgs::command().get_matches();
     let config_path = matches.get_one::<std::path::PathBuf>("config_path");
 
@@ -35,6 +41,7 @@ fn main() -> Result<()> {
         println!("Protocol version: {VERSION}");
         return Ok(());
     }
+
     let conf =
         read_server_config(&proxy_config.config).context("Cannot read configuration file")?;
     if let Err(err) = proxy::run(&conf, &proxy_config) {

--- a/sanzu/src/bin/sanzu_proxy.rs
+++ b/sanzu/src/bin/sanzu_proxy.rs
@@ -7,15 +7,13 @@ extern crate log;
 use sanzu::{
     config::read_server_config,
     proxy,
-    utils::{ProxyArgs, ProxyArgsConfig},
+    utils::{init_logger, ProxyArgs, ProxyArgsConfig},
 };
 use sanzu_common::proto::VERSION;
 
 use twelf::Layer;
 
 fn main() -> Result<()> {
-    env_logger::Builder::from_default_env().init();
-
     let matches = ProxyArgs::command().get_matches();
     let config_path = matches.get_one::<std::path::PathBuf>("config_path");
 
@@ -30,6 +28,8 @@ fn main() -> Result<()> {
     ]);
 
     let proxy_config = ProxyArgsConfig::with_layers(&layers).unwrap();
+
+    init_logger(proxy_config.verbose);
 
     if proxy_config.proto {
         println!("Protocol version: {VERSION}");

--- a/sanzu/src/bin/sanzu_server.rs
+++ b/sanzu/src/bin/sanzu_server.rs
@@ -9,16 +9,12 @@ use twelf::Layer;
 use sanzu::{
     config::read_server_config,
     server,
-    utils::{ServerArgs, ServerArgsConfig},
+    utils::{init_logger, ServerArgs, ServerArgsConfig},
 };
 
 use sanzu_common::proto::VERSION;
 
 fn main() -> Result<()> {
-    env_logger::Builder::from_default_env()
-        .format_timestamp_nanos()
-        .init();
-
     let matches = ServerArgs::command().get_matches();
     let config_path = matches.get_one::<std::path::PathBuf>("config_path");
 
@@ -33,6 +29,8 @@ fn main() -> Result<()> {
     ]);
 
     let server_config = ServerArgsConfig::with_layers(&layers).unwrap();
+
+    init_logger(server_config.verbose);
 
     if server_config.proto {
         println!("Protocol version: {VERSION}");

--- a/sanzu/src/bin/sanzu_server.rs
+++ b/sanzu/src/bin/sanzu_server.rs
@@ -1,20 +1,25 @@
 use anyhow::{Context, Result};
+use clap::CommandFactory;
 
 #[macro_use]
 extern crate log;
 
-use clap::CommandFactory;
-use twelf::Layer;
-
 use sanzu::{
     config::read_server_config,
     server,
-    utils::{init_logger, ServerArgs, ServerArgsConfig},
+    utils::{init_logger, is_proto_arg, ServerArgs, ServerArgsConfig},
 };
 
 use sanzu_common::proto::VERSION;
 
+use twelf::Layer;
+
 fn main() -> Result<()> {
+    if is_proto_arg() {
+        println!("Protocol version: {VERSION}");
+        return Ok(());
+    }
+
     let matches = ServerArgs::command().get_matches();
     let config_path = matches.get_one::<std::path::PathBuf>("config_path");
 
@@ -36,6 +41,7 @@ fn main() -> Result<()> {
         println!("Protocol version: {VERSION}");
         return Ok(());
     }
+
     let conf =
         read_server_config(&server_config.config).context("Cannot read configuration file")?;
     if let Err(err) = server::run(&conf, &server_config) {

--- a/sanzu/src/bin/sanzu_server.rs
+++ b/sanzu/src/bin/sanzu_server.rs
@@ -3,220 +3,44 @@ use anyhow::{Context, Result};
 #[macro_use]
 extern crate log;
 
-use clap::{Arg, ArgAction, Command};
+use clap::CommandFactory;
+use twelf::Layer;
 
-use sanzu::{config::read_server_config, server, utils::ArgumentsSrv};
+use sanzu::{
+    config::read_server_config,
+    server,
+    utils::{ServerArgs, ServerArgsConfig},
+};
 
 use sanzu_common::proto::VERSION;
-
-const DEFAULT_CONFIG: &str = "/etc/sanzu.toml";
 
 fn main() -> Result<()> {
     env_logger::Builder::from_default_env()
         .format_timestamp_nanos()
         .init();
 
-    let about = format!(
-        r#"Sanzu server: desktop video streaming
+    let matches = ServerArgs::command().get_matches();
+    let config_path = matches.get_one::<std::path::PathBuf>("config_path");
 
-Protocol version: {VERSION:?}
-"#
-    );
-
-    let matches = Command::new("Sanzu server")
-        .version(env!("CARGO_PKG_VERSION"))
-        .about(about)
-        .arg(
-            Arg::new("config")
-                .short('f')
-                .long("config")
-                .help("configuration file")
-                .default_value(DEFAULT_CONFIG)
-                .num_args(1),
-        )
-        .arg(
-            Arg::new("vsock")
-                .short('v')
-                .long("vsock")
-                .action(ArgAction::SetTrue)
-                .help("Use vsock"),
-        )
-        .arg(
-            Arg::new("unixsock")
-                .short('u')
-                .long("unixsock")
-                .action(ArgAction::SetTrue)
-                .help("Use unixsocket"),
-        )
-        .arg(
-            Arg::new("connect-unixsock")
-                .short('c')
-                .long("connect-unixsock")
-                .action(ArgAction::SetTrue)
-                .help("connect to unixsocket instead of listening"),
-        )
-        .arg(
-            Arg::new("listen")
-                .short('l')
-                .long("listen")
-                .num_args(1)
-                .default_value("127.0.0.1")
-                .help("Listen address"),
-        )
-        .arg(
-            Arg::new("stdio")
-                .short('m')
-                .long("stdio")
-                .action(ArgAction::SetTrue)
-                .help("Uses STDIO instead of listining on a TCP port"),
-        )
-        .arg(
-            Arg::new("port")
-                .short('p')
-                .long("port")
-                .num_args(1)
-                .default_value("1122")
-                .help("Bind port number"),
-        )
-        .arg(
-            Arg::new("encoder")
-                .short('e')
-                .long("encoder")
-                .num_args(1)
-                .help("Encoder name (libx264, h264_nvenc, ...)"),
-        )
-        .arg(
-            Arg::new("seamless")
-                .help("Seamless mode")
-                .short('s')
-                .long("seamless")
-                .action(ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("keep_server_resolution")
-                .help("Server will keep it's resolution")
-                .short('x')
-                .long("keep_server_resolution")
-                .action(ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("audio")
-                .help("Allow audio forwarding")
-                .short('a')
-                .long("audio")
-                .action(ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("raw_sound")
-                .short('r')
-                .long("raw_sound")
-                .action(ArgAction::SetTrue)
-                .help("Transmit Raw sound"),
-        )
-        .arg(
-            Arg::new("export_video_pci")
-                .short('i')
-                .long("export_video_pci")
-                .action(ArgAction::SetTrue)
-                .help(
-                    "Export video to a pci shared memory\n\
-                     Example: if the video server runs in a vm,\n\
-                     the video buffer is exfiltrated using guest/host shared memory instead of\n\
-                     tcp or vsock",
-                ),
-        )
-        .arg(
-            Arg::new("use_extern_img_source")
-                .short('k')
-                .long("use_extern_img_source")
-                .num_args(1)
-                .help(
-                    "Do not extract image from x11\n\
-                     Example: if you use Xvfb you can use Xvfb backbuffer file\n\
-                     instead of extracting images from x11 server",
-                ),
-        )
-        .arg(
-            Arg::new("avoid_img_extraction")
-                .short('j')
-                .long("avoid_img_extraction")
-                .action(ArgAction::SetTrue)
-                .help(
-                    "The video server considers that image extraction will be done by\n\
-                     another process. Empty images will we sent to client.\n\
-                     Use case: combined with a proxy encoder from a virtual machine",
-                ),
-        )
-        .arg(
-            Arg::new("restrict-clipboard")
-                .help("Don't send clipboard to client")
-                .short('q')
-                .long("restrict-clipboard")
-                .action(ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("rdonly")
-                .help("Read only server")
-                .short('o')
-                .long("rdonly")
-                .action(ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("loop")
-                .help("Endless server clients")
-                .short('d')
-                .long("loop")
-                .action(ArgAction::SetTrue),
-        )
-        .get_matches();
-
-    let address = matches.get_one::<String>("listen").unwrap();
-
-    let port = matches.get_one::<String>("port").unwrap();
-
-    let seamless = matches.get_flag("seamless");
-    let keep_server_resolution = matches.get_flag("keep_server_resolution");
-    let audio = matches.get_flag("audio");
-    let encoder_name = matches
-        .get_one::<String>("encoder")
-        .unwrap_or(&"libx264".to_string())
-        .to_owned();
-
-    let raw_sound = matches.get_flag("raw_sound");
-    let conf = read_server_config(matches.get_one::<String>("config").unwrap())
-        .context("Cannot read configuration file")?;
-    let vsock = matches.get_flag("vsock");
-    let stdio = matches.get_flag("stdio");
-    let unixsock = matches.get_flag("unixsock");
-    let connect_unixsock = matches.get_flag("connect-unixsock");
-    let export_video_pci = matches.get_flag("export_video_pci");
-    let restrict_clipboard = matches.get_flag("restrict-clipboard");
-    let extern_img_source = matches.get_one::<String>("use_extern_img_source").cloned();
-    let avoid_img_extraction = matches.get_flag("avoid_img_extraction");
-    let rdonly = matches.get_flag("rdonly");
-    let endless_loop = matches.get_flag("loop");
-
-    let arguments = ArgumentsSrv {
-        vsock,
-        stdio,
-        unixsock,
-        connect_unixsock,
-        address,
-        port,
-        encoder_name,
-        seamless,
-        keep_server_resolution,
-        audio,
-        raw_sound,
-        export_video_pci,
-        restrict_clipboard,
-        extern_img_source,
-        avoid_img_extraction,
-        rdonly,
-        endless_loop,
+    let mut layers = if let Some(config_path) = config_path {
+        vec![Layer::Toml(config_path.into())]
+    } else {
+        vec![]
     };
+    layers.append(&mut vec![
+        Layer::Env(Some(String::from("SANZU_"))),
+        Layer::Clap(matches),
+    ]);
 
-    if let Err(err) = server::run(&conf, &arguments) {
+    let server_config = ServerArgsConfig::with_layers(&layers).unwrap();
+
+    if server_config.proto {
+        println!("Protocol version: {VERSION}");
+        return Ok(());
+    }
+    let conf =
+        read_server_config(&server_config.config).context("Cannot read configuration file")?;
+    if let Err(err) = server::run(&conf, &server_config) {
         error!("Server error");
         err.chain().for_each(|cause| error!(" - due to {}", cause));
     }

--- a/sanzu/src/client_wind3d.rs
+++ b/sanzu/src/client_wind3d.rs
@@ -1,6 +1,6 @@
 use crate::{
     client_utils::{Area, Client},
-    utils::{ArgumentsClient, ClipboardConfig},
+    utils::{ClientArgsConfig, ClipboardConfig},
     utils_win,
 };
 use anyhow::{Context, Result};
@@ -1172,10 +1172,19 @@ fn set_window_cursor(cursor_data: &[u8], width: u32, height: u32, xhot: i32, yho
 }
 
 pub fn init_wind3d(
-    argumets: &ArgumentsClient,
+    arguments: &ClientArgsConfig,
     mut seamless: bool,
     server_size: Option<(u16, u16)>,
 ) -> Result<Box<dyn Client>> {
+    let clipboard_config = match arguments.clipboard.as_str() {
+        "allow" => ClipboardConfig::Allow,
+        "deny" => ClipboardConfig::Deny,
+        "trig" => ClipboardConfig::Trig,
+        _ => {
+            return Err(anyhow!("Unknown clipboard config: {}", arguments.clipboard));
+        }
+    };
+
     let (
         client_info,
         frame_receiver,
@@ -1185,13 +1194,13 @@ pub fn init_wind3d(
         session_receiver,
     ) = ClientWindows::build(
         server_size,
-        argumets.clipboard_config,
-        argumets.printdir.clone(),
-        argumets.sync_key_locks,
+        clipboard_config,
+        arguments.allow_print.clone(),
+        arguments.sync_key_locks,
     );
     let (screen_width, screen_height) = (client_info.width, client_info.height);
-    let window_mode = argumets.window_mode;
-    let window_title = argumets.title.clone().as_bytes().to_vec();
+    let window_mode = arguments.window_mode;
+    let window_title = arguments.title.clone().as_bytes().to_vec();
 
     if window_mode {
         seamless = false;

--- a/sanzu/src/proxy_windows.rs
+++ b/sanzu/src/proxy_windows.rs
@@ -1,6 +1,6 @@
-use crate::{config::ConfigServer, utils::ArgumentsProxy};
+use crate::{config::ConfigServer, utils::ProxyArgsConfig};
 use anyhow::Result;
 
-pub fn run(_config: &ConfigServer, _arguments: &ArgumentsProxy) -> Result<()> {
+pub fn run(_config: &ConfigServer, _arguments: &ProxyArgsConfig) -> Result<()> {
     panic!("Unsupported os");
 }

--- a/sanzu/src/server_windows.rs
+++ b/sanzu/src/server_windows.rs
@@ -1,7 +1,7 @@
 use crate::{
     config::ConfigServer,
     server_utils::Server,
-    utils::{ArgumentsSrv, ServerEvent},
+    utils::{ServerArgsConfig, ServerEvent},
     utils_win,
     video_encoder::{Encoder, EncoderTimings},
 };
@@ -755,7 +755,7 @@ pub fn init_d3d11() -> Result<()> {
 }
 
 pub fn init_win(
-    _arguments: &ArgumentsSrv,
+    _arguments: &ServerArgsConfig,
     config: &ConfigServer,
     _server_size: Option<(u16, u16)>,
 ) -> Result<Box<dyn Server>> {

--- a/sanzu/src/server_x11.rs
+++ b/sanzu/src/server_x11.rs
@@ -2,7 +2,7 @@ use crate::{
     config::ConfigServer,
     server_utils::Server,
     utils::ClipboardSelection,
-    utils::{get_xwd_data, ArgumentsSrv, ServerEvent},
+    utils::{get_xwd_data, ServerArgsConfig, ServerEvent},
     utils_x11,
     video_encoder::{Encoder, EncoderTimings},
 };
@@ -703,7 +703,7 @@ fn del_custom_video_mode<C: Connection>(conn: &C, window: Window) -> Result<()> 
 
 /// Initialize x11rb server handler
 pub fn init_x11rb(
-    arguments: &ArgumentsSrv,
+    arguments: &ServerArgsConfig,
     config: &ConfigServer,
     server_size: Option<(u16, u16)>,
 ) -> Result<Box<dyn Server>> {

--- a/sanzu/src/utils.rs
+++ b/sanzu/src/utils.rs
@@ -55,7 +55,6 @@ pub struct ServerArgsConfig {
     pub config: String,
     #[clap(
         long,
-        short = 'v',
         default_value_t = false,
         help = "Use vsock for communication layer"
     )]
@@ -171,6 +170,8 @@ tcp or vsock"
     pub keep_listening: bool,
     #[clap(long, help = "Displays protocol version")]
     pub proto: bool,
+    #[clap(short='v', long, action = clap::ArgAction::Count)]
+    pub verbose: u8,
 }
 
 #[derive(Parser, Debug)]
@@ -210,7 +211,6 @@ pub struct ClientArgsConfig {
     #[cfg(unix)]
     #[clap(
         long,
-        short = 'v',
         default_value_t = false,
         help = "Use vsock for communication layer"
     )]
@@ -315,6 +315,8 @@ without being interpreted by the local window manager"
     pub grab_keyboard: bool,
     #[clap(long, help = "Displays protocol version")]
     pub proto: bool,
+    #[clap(short='v', long, action = clap::ArgAction::Count)]
+    pub verbose: u8,
 }
 
 #[derive(Parser, Debug)]
@@ -350,7 +352,6 @@ pub struct ProxyArgsConfig {
     pub config: String,
     #[clap(
         long,
-        short = 'v',
         default_value_t = false,
         help = "Use vsock for communication layer"
     )]
@@ -401,6 +402,8 @@ pub struct ProxyArgsConfig {
     pub keep_listening: bool,
     #[clap(long, help = "Displays protocol version")]
     pub proto: bool,
+    #[clap(short='v', long, action = clap::ArgAction::Count)]
+    pub verbose: u8,
 }
 
 const MAX_HEADER_SIZE: u32 = 0x100;
@@ -459,4 +462,28 @@ pub fn get_xwd_data(data: &[u8]) -> Result<(&[u8], u32, u32, u32)> {
         window_y,
         bytes_per_line,
     ))
+}
+
+/// Logger uses env var to set default log level
+/// Change log level according to verbose option
+pub fn init_logger(level: u8) {
+    let mut log_builder = env_logger::Builder::from_default_env();
+    log_builder.format_timestamp_nanos();
+    match level {
+        0 => {}
+        1 => {
+            log_builder.filter_level(log::LevelFilter::Warn);
+        }
+        2 => {
+            log_builder.filter_level(log::LevelFilter::Info);
+        }
+        3 => {
+            log_builder.filter_level(log::LevelFilter::Debug);
+        }
+        _ => {
+            log_builder.filter_level(log::LevelFilter::Trace);
+        }
+    }
+
+    log_builder.init();
 }

--- a/sanzu/src/utils.rs
+++ b/sanzu/src/utils.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use byteorder::{BigEndian, ByteOrder};
 use std::net::IpAddr;
 
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use twelf::config;
 
 pub enum ServerEvent {
@@ -486,4 +486,25 @@ pub fn init_logger(level: u8) {
     }
 
     log_builder.init();
+}
+
+#[derive(Parser, Debug)]
+pub struct ProtoArgs {
+    #[clap(long, default_value_t = false, help = "Display proto version")]
+    pub proto: bool,
+}
+
+/// Test if the only argument is --proto
+/// TODO: what we want here is an argument which can override mandatory positional arguments
+/// The goal is to allow for example "sanzu_client --proto" even if sanzu_client
+/// needs 2 positional arguments. To do this, we build a dummy clap parser with
+/// only one argument.
+/// Don't forget to add proto in the real command line.
+pub fn is_proto_arg() -> bool {
+    if let Ok(matches) = ProtoArgs::command().try_get_matches() {
+        if *matches.get_one::<bool>("proto").unwrap() {
+            return true;
+        }
+    }
+    false
 }

--- a/sanzu/src/utils.rs
+++ b/sanzu/src/utils.rs
@@ -2,6 +2,9 @@ use anyhow::Result;
 use byteorder::{BigEndian, ByteOrder};
 use std::net::IpAddr;
 
+use clap::Parser;
+use twelf::config;
+
 pub enum ServerEvent {
     ResolutionChange(u32, u32),
 }
@@ -19,64 +22,385 @@ pub enum ClipboardConfig {
     Trig,
 }
 
-pub struct ArgumentsSrv<'a> {
+#[derive(Parser, Debug)]
+#[clap(author, version, about)]
+pub struct ServerArgs {
+    /// Config file
+    #[clap(
+        short,
+        long = "config_path",
+        help = r"Path of toml file storing *arguments* configuration.
+Sanzu arguments can be set regarding this priority:
+- this configuration file
+- environment variable
+- command line"
+    )]
+    pub config_path: Option<std::path::PathBuf>,
+
+    /// Rest of arguments
+    #[clap(flatten)]
+    pub server_config: ServerArgsConfig,
+}
+
+#[config]
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+pub struct ServerArgsConfig {
+    #[clap(
+        long,
+        short = 'f',
+        default_value = "/etc/sanzu.toml",
+        help = "Sanzu server configuration file (video compression configuration, ...)"
+    )]
+    pub config: String,
+    #[clap(
+        long,
+        short = 'v',
+        default_value_t = false,
+        help = "Use vsock for communication layer"
+    )]
     pub vsock: bool,
+    #[clap(
+        long,
+        short = 'm',
+        default_value_t = false,
+        help = "Use STDIO for communication layer"
+    )]
     pub stdio: bool,
+    #[clap(
+        long,
+        short = 'u',
+        default_value_t = false,
+        help = "Use unix socket for communication layer"
+    )]
     pub unixsock: bool,
+    #[clap(
+        long,
+        short = 'c',
+        default_value_t = false,
+        help = "Connect to unixsocket instead of listening"
+    )]
     pub connect_unixsock: bool,
-    pub address: &'a str,
-    pub port: &'a str,
-    pub encoder_name: String,
+    #[clap(
+        long,
+        short = 'l',
+        default_value = "127.0.0.1",
+        help = "Listen address. Subnet or unix path"
+    )]
+    pub address: String,
+    #[clap(long, short = 'p', default_value = "1122", help = "Bind port number")]
+    pub port: String,
+    #[clap(
+        long,
+        short = 'e',
+        default_value = "libx264",
+        help = "Encoder name. Ex: libx264, h264_qsv, hevc_nvenc"
+    )]
+    pub encoder: String,
+    #[clap(
+        long,
+        short = 's',
+        default_value_t = false,
+        help = "Seamless mode. Integrate remote windows in local environement"
+    )]
     pub seamless: bool,
+    #[clap(
+        long,
+        short = 'x',
+        default_value_t = false,
+        help = "Server will keep it's resolution"
+    )]
     pub keep_server_resolution: bool,
+    #[clap(
+        long,
+        short = 'a',
+        default_value_t = false,
+        help = "Allow audio forwarding from server to client"
+    )]
     pub audio: bool,
+    #[clap(
+        long,
+        short = 'r',
+        default_value_t = false,
+        help = "Transmit Raw sound (not encoded)"
+    )]
     pub raw_sound: bool,
+    #[clap(
+        long,
+        short = 'i',
+        default_value_t = false,
+        help = r"Export video to a pci shared memory
+Example: if the video server runs in a vm,
+the video buffer is exfiltrated using guest/host shared memory instead of
+tcp or vsock"
+    )]
     pub export_video_pci: bool,
+    #[clap(
+        long,
+        short = 'q',
+        default_value_t = false,
+        help = "Disallow sending clipboard from server to client"
+    )]
     pub restrict_clipboard: bool,
+    #[clap(
+        long,
+        short = 'k',
+        help = "Use video source from file instead of video server api"
+    )]
     pub extern_img_source: Option<String>,
+    #[clap(
+        long,
+        short = 'j',
+        default_value_t = false,
+        help = "Skip video processing (use with sanzy_proxy for example)"
+    )]
     pub avoid_img_extraction: bool,
+    #[clap(
+        long,
+        short = 'o',
+        default_value_t = false,
+        help = "Simply stream video: client cannot interact"
+    )]
     pub rdonly: bool,
-    pub endless_loop: bool,
+    #[clap(
+        long,
+        short = 'd',
+        default_value_t = false,
+        help = "Loop if client disconnect instead of quitting"
+    )]
+    pub keep_listening: bool,
+    #[clap(long, help = "Displays protocol version")]
+    pub proto: bool,
 }
 
-pub struct ArgumentsClient<'a> {
-    pub server_addr: &'a str,
+#[derive(Parser, Debug)]
+#[clap(author, version, about)]
+pub struct ClientArgs {
+    /// Config file
+    #[clap(
+        short,
+        long = "config_path",
+        help = r"Path of toml file storing *arguments* configuration.
+Sanzu arguments can be set regarding this priority:
+- this configuration file
+- environment variable
+- command line"
+    )]
+    pub config_path: Option<std::path::PathBuf>,
+
+    /// Rest of arguments
+    #[clap(flatten)]
+    pub client_config: ClientArgsConfig,
+}
+
+#[config]
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+pub struct ClientArgsConfig {
+    #[clap(help = "Sanzu server address")]
+    pub server_addr: String,
+    #[clap(help = "Sanzu server port")]
     pub server_port: u16,
+    #[clap(
+        long,
+        short = 'f',
+        help = "Sanzu client configuration file (video decompression configuration, ...)"
+    )]
+    pub config: Option<String>,
     #[cfg(unix)]
+    #[clap(
+        long,
+        short = 'v',
+        default_value_t = false,
+        help = "Use vsock for communication layer"
+    )]
     pub vsock: bool,
+    #[clap(
+        long,
+        short = 'a',
+        default_value_t = false,
+        help = "Allow audio forwarding from server to client"
+    )]
     pub audio: bool,
+    #[clap(long, short = 's', help = "Audio sample rate")]
     pub audio_sample_rate: Option<u32>,
+    #[clap(
+        long,
+        short = 'b',
+        default_value_t = 150,
+        help = "Audio buffer length (default 150ms)"
+    )]
     pub audio_buffer_ms: u32,
+    #[cfg(feature = "kerberos")]
+    #[clap(long, short = 'k', help = "Enable kerberos using server cname")]
     pub server_cname: Option<String>,
+    #[clap(
+        long,
+        short = 't',
+        help = "Enable tls encryption / server authentication"
+    )]
     pub tls_ca: Option<String>,
+    #[clap(long, short = 'n', help = "Server name for tls tunnel")]
     pub tls_server_name: Option<String>,
+    #[clap(long, short = 'c', help = "Use client cert authentication")]
     pub client_cert: Option<String>,
+    #[clap(
+        long,
+        short = 'x',
+        help = "Client private key used in tls authentication"
+    )]
     pub client_key: Option<String>,
+    #[clap(long, short = 'l', help = "Use login/password to authenticate")]
     pub login: bool,
-    pub clipboard_config: ClipboardConfig,
+    #[clap(
+        long,
+        short = 'q',
+        default_value = "allow",
+        help = r#"Control clipboard behavior:
+ - allow: send clipboard to server on local clipboard modification
+ - deny: never send local clipboard to server
+ - trig: send local clipboard to server on hitting special shortcut
+"#
+    )]
+    pub clipboard: String,
+    #[clap(
+        long,
+        short = 'w',
+        help = "Client will be in window mode instead of fullscreen"
+    )]
     pub window_mode: bool,
-    pub decoder_name: Option<String>,
-    pub printdir: Option<String>,
+    #[clap(
+        long,
+        short = 'd',
+        help = "Force decoder name (libx264, h264_qsv, ...) (must be compatible with selected encoder)"
+    )]
+    pub decoder: Option<String>,
+    #[clap(
+        long,
+        short = 'j',
+        help = r#""Allow print order from serveur to local printing service.
+The argument is the local firectory base which contains files to print
+Ex: -j c:\user\dupond\printdir\
+"#
+    )]
+    pub allow_print: Option<String>,
+    #[clap(long, short = 'p', help = "Command to execute to establish connection")]
     pub proxycommand: Option<String>,
+    #[clap(long, short = 'g', help = "Synchronize caps/num/scroll lock")]
     pub sync_key_locks: bool,
-    pub video_shared_mem: Option<String>,
-    pub shm_is_xwd: bool,
-    pub title: &'a str,
+    #[clap(
+        long,
+        short = 'i',
+        help = r"Input video from shared memory
+Example: if the video server runs in a vm,
+the video buffer is exfiltrated using guest/host shared memory instead of
+tcp or vsock"
+    )]
+    pub extern_img_source: Option<String>,
+    #[clap(long, short = 'y', help = "Input from shared memory is in xwd format")]
+    pub source_is_xwd: bool,
+    #[clap(
+        long,
+        default_value = "Sanzu",
+        help = "Window's title (default: 'Sanzu client')"
+    )]
+    pub title: String,
+    #[clap(
+        long,
+        short = 'u',
+        help = r"Grab and keep keyboard on focus.
+This allows (linux) sending special keys like alt-tab
+without being interpreted by the local window manager"
+    )]
     pub grab_keyboard: bool,
+    #[clap(long, help = "Displays protocol version")]
+    pub proto: bool,
 }
 
-pub struct ArgumentsProxy<'a> {
+#[derive(Parser, Debug)]
+#[clap(author, version, about)]
+pub struct ProxyArgs {
+    /// Config file
+    #[clap(
+        short,
+        long = "config_path",
+        help = r"Path of toml file storing *arguments* configuration.
+Sanzu arguments can be set regarding this priority:
+- this configuration file
+- environment variable
+- command line"
+    )]
+    pub config_path: Option<std::path::PathBuf>,
+
+    /// Rest of arguments
+    #[clap(flatten)]
+    pub proxy_config: ProxyArgsConfig,
+}
+
+#[config]
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+pub struct ProxyArgsConfig {
+    #[clap(
+        long,
+        short = 'f',
+        default_value = "/etc/sanzu.toml",
+        help = "Sanzu server configuration file (video compression configuration, ...)"
+    )]
+    pub config: String,
+    #[clap(
+        long,
+        short = 'v',
+        default_value_t = false,
+        help = "Use vsock for communication layer"
+    )]
     pub vsock: bool,
-    pub server_addr: &'a str,
-    pub server_port: &'a str,
+    #[clap(help = "Sanzu server address")]
+    pub server_addr: String,
+    #[clap(help = "Sanzu server port")]
+    pub server_port: String,
+    #[clap(
+        long,
+        short = 'l',
+        default_value = "127.0.0.1",
+        help = "Listen address. Subnet or unix path"
+    )]
     pub listen_address: IpAddr,
+    #[clap(long, short = 'p', default_value = "1122", help = "Bind port number")]
     pub listen_port: Option<u16>,
+    #[clap(long, short = 'u', help = "Use unix socket for communication layer")]
     pub unix_socket: Option<String>,
-    pub encoder_name: String,
+    #[clap(
+        long,
+        short = 'e',
+        default_value = "libx264",
+        help = "Encoder name. Ex: libx264, h264_qsv, hevc_nvenc"
+    )]
+    pub encoder: String,
+    #[clap(
+        long,
+        short = 'a',
+        default_value_t = false,
+        help = "Allow audio forwarding from server to client"
+    )]
     pub audio: bool,
-    pub video_shared_mem: Option<String>,
-    pub shm_is_xwd: bool,
-    pub endless_loop: bool,
+    #[clap(
+        long,
+        short = 'k',
+        help = "Use video source from file instead of video server api"
+    )]
+    pub extern_img_source: Option<String>,
+    #[clap(long, short = 'w', help = "Video source is xwd formated")]
+    pub source_is_xwd: bool,
+    #[clap(
+        long,
+        short = 'd',
+        default_value_t = false,
+        help = "Loop if client disconnect instead of quitting"
+    )]
+    pub keep_listening: bool,
+    #[clap(long, help = "Displays protocol version")]
+    pub proto: bool,
 }
 
 const MAX_HEADER_SIZE: u32 = 0x100;


### PR DESCRIPTION
With this PR, arguments of client/server/proxy can be taken (by priority):
- arguments config file (toml)
- environment variables
- command line arguments

:warning: this PR changes some arguments name:
- `loop` argument renamed to `keep-listening`
- `clipboard_config` argument renamed to `clipboard`
- `printdir` argument renamed to `allow-print`
- `import_video_shm` argument renamed to `extern_img_source`
- `shm_is_xwd` argument renamed to `source_is_xwd`

Log level could be set using RUST_LOG environment variable, we now can additionally use `-v`, `-vv`, ... to change it using command line.
