### PR TITLE
Clean command line options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- extern-img-source short version is '-k' for all binaries
+### Fixed
+- Remove default listen port for sanzu_proxy (resulting in vsock err)
+### Removed
+- '-i' short version for "--export-video-pci" for sanzu_server
+
 ## [0.1.3] - 2023-05-16
 
 ### Changed

--- a/sanzu/src/utils.rs
+++ b/sanzu/src/utils.rs
@@ -126,7 +126,6 @@ pub struct ServerArgsConfig {
     pub raw_sound: bool,
     #[clap(
         long,
-        short = 'i',
         default_value_t = false,
         help = r"Export video to a pci shared memory
 Example: if the video server runs in a vm,
@@ -290,14 +289,14 @@ Ex: -j c:\user\dupond\printdir\
     pub sync_key_locks: bool,
     #[clap(
         long,
-        short = 'i',
+        short = 'k',
         help = r"Input video from shared memory
 Example: if the video server runs in a vm,
 the video buffer is exfiltrated using guest/host shared memory instead of
 tcp or vsock"
     )]
     pub extern_img_source: Option<String>,
-    #[clap(long, short = 'y', help = "Input from shared memory is in xwd format")]
+    #[clap(long, short = 'y', help = "Video source is xwd formated")]
     pub source_is_xwd: bool,
     #[clap(
         long,
@@ -367,7 +366,7 @@ pub struct ProxyArgsConfig {
         help = "Listen address. Subnet or unix path"
     )]
     pub listen_address: IpAddr,
-    #[clap(long, short = 'p', default_value = "1122", help = "Bind port number")]
+    #[clap(long, short = 'p', help = "Bind port number")]
     pub listen_port: Option<u16>,
     #[clap(long, short = 'u', help = "Use unix socket for communication layer")]
     pub unix_socket: Option<String>,
@@ -391,7 +390,7 @@ pub struct ProxyArgsConfig {
         help = "Use video source from file instead of video server api"
     )]
     pub extern_img_source: Option<String>,
-    #[clap(long, short = 'w', help = "Video source is xwd formated")]
+    #[clap(long, short = 'y', help = "Video source is xwd formated")]
     pub source_is_xwd: bool,
     #[clap(
         long,


### PR DESCRIPTION
/!\ Some options are changed
for Example since v0.1.3:
--tls_ca becomes --tls-ca
See change log for details