### PR TITLE
Fix windows build

### DIFF
--- a/build/Dockerfile-windows
+++ b/build/Dockerfile-windows
@@ -11,7 +11,7 @@ RUN set -eux; \
     pacman -Sy archlinux-keyring --noconfirm;
 
 RUN set -eux; \
-    echo 'Server = http://ftp.u-strasbg.fr/linux/distributions/archlinux/$repo/os/$arch' > /etc/pacman.d/mirrorlist ;
+    echo 'Server = https://geo.mirror.pkgbuild.com/$repo/os/$arch' > /etc/pacman.d/mirrorlist ;
 
 RUN set -eux; \
     pacman-key --populate; \

--- a/build/Dockerfile-windows
+++ b/build/Dockerfile-windows
@@ -55,7 +55,7 @@ RUN set -eux; \
       rsync \
       curl ; \
     cd /tmp ; \
-    curl -L -o /tmp/ffmpeg.zip https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n4.4-latest-win64-gpl-shared-4.4.zip ; \
+    curl -L -o /tmp/ffmpeg.zip https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n6.1-latest-win64-gpl-shared-6.1.zip ; \
     unzip /tmp/ffmpeg.zip ; cd /tmp/ffmpeg*/bin/ ; \
     for lib in *.dll ; do echo ${lib} ; \
         cp $lib /usr/x86_64-w64-mingw32/lib/${lib} ; \


### PR DESCRIPTION
Hello :wave:,
I had two errors when building sanzu for windows.
1. 404 error when running `pacman -Syu`
2. Error because the tarball of ffmpeg was removed from the repo (due to the xz drama)

This PR makes it possible to build again for windows by
1. Changing the archlinux mirror used
2. Updating the ffmpeg tarball 

On the "latest" channel, there is no n4.x version anymore for ffmpeg so I used version n6.1. It seems to work fine from my limited testing (machine with an intel gpu using `h264_qsv`)
